### PR TITLE
Fixed new UI run widget icon theming.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+## 88.3-1.0.8 [EXP UI Fix]
+
+### Fixed
+
+- Icon theming not working in run widget of the new UI.
+
 ## 88.3-1.0.7 [EXP UI Fix]
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 
 pluginGroup = io.unthrottled.doki.icons
 pluginName = Doki Theme Icons
-pluginVersion = 88.3-1.0.7
+pluginVersion = 88.3-1.0.8
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 222

--- a/shared/src/main/kotlin/io/unthrottled/doki/icons/jetbrains/shared/integrations/PlatformHacker.kt
+++ b/shared/src/main/kotlin/io/unthrottled/doki/icons/jetbrains/shared/integrations/PlatformHacker.kt
@@ -74,6 +74,29 @@ object PlatformHacker : Logging {
     }) {
       logger().warn("Unable to hack 'fixEXPUIRunWidget' for raisins", it)
     }
+
+    runSafely({
+      val cp = ClassPool(true)
+      cp.insertClassPath(
+        ClassClassPath(
+          Class.forName("com.intellij.execution.ui.RunState")
+        )
+      )
+      val ctClass = cp.get("com.intellij.execution.ui.RedesignedRunConfigurationSelector")
+      val doPaintText = ctClass.getDeclaredMethods("update")[0]
+      doPaintText.instrument(
+        object : ExprEditor() {
+          override fun edit(m: MethodCall?) {
+            if (m?.methodName == "toStrokeIcon") {
+              m.replace("{ \$_ = \$1; }")
+            }
+          }
+        }
+      )
+      ctClass.toClass()
+    }) {
+      logger().warn("Unable to hack 'fixEXPUIRunWidget' try two for raisins", it)
+    }
   }
 
   private fun fixEXPUIButton() {


### PR DESCRIPTION
## Changes

### Fixed

- Icon theming not working in run widget of the new UI.

## Screens

**Before**
<img width="251" alt="Screenshot 2023-02-14 at 5 36 35 AM" src="https://user-images.githubusercontent.com/15972415/218728071-b83712b7-5f5c-4dde-8b3e-79f10c5d4c67.png">

**After**
<img width="284" alt="Screenshot 2023-02-14 at 5 37 51 AM" src="https://user-images.githubusercontent.com/15972415/218728135-d206bf58-bfde-4d52-9895-f465d27ddeaf.png">




